### PR TITLE
Add support for federating ban expiration and ban+remove command

### DIFF
--- a/crates/lemmy_client/src/model.rs
+++ b/crates/lemmy_client/src/model.rs
@@ -42,6 +42,7 @@ pub enum ModlogBan {
         user: Person,
         is_banned: bool,
         reason: Option<String>,
+        expires: Option<DateTime<Utc>>,
     },
     Community {
         moderator: Person,
@@ -49,6 +50,7 @@ pub enum ModlogBan {
         community: Community,
         is_banned: bool,
         reason: Option<String>,
+        expires: Option<DateTime<Utc>>,
     },
 }
 
@@ -60,17 +62,22 @@ impl Display for ModlogBan {
                 user,
                 is_banned,
                 reason,
+                expires,
             } => {
                 write!(
                     f,
                     "* site_ban = `{}`\r\n\
                     * user = {}\r\n\
                     * mod = {}\r\n\
-                    * reason = `{}`",
+                    * reason = `{}`\r\n\
+                    * expires = `{}`",
                     is_banned,
                     user,
                     moderator,
-                    reason.clone().unwrap_or_default()
+                    reason.clone().unwrap_or_default(),
+                    expires
+                        .map(|exp| exp.to_rfc3339())
+                        .unwrap_or("N/A".to_string())
                 )
             }
             ModlogBan::Community {
@@ -79,6 +86,7 @@ impl Display for ModlogBan {
                 community,
                 is_banned,
                 reason,
+                expires,
             } => {
                 write!(
                     f,
@@ -86,12 +94,16 @@ impl Display for ModlogBan {
                     * user = {}\r\n\
                     * community = {}\r\n\
                     * mod = {}\r\n\
-                    * reason = `{}`",
+                    * reason = `{}`\r\n\
+                    * expires = `{}`",
                     is_banned,
                     user,
                     community,
                     moderator,
-                    reason.clone().unwrap_or_default()
+                    reason.clone().unwrap_or_default(),
+                    expires
+                        .map(|exp| exp.to_rfc3339())
+                        .unwrap_or("N/A".to_string())
                 )
             }
         }

--- a/crates/lemmy_client/src/modlog.rs
+++ b/crates/lemmy_client/src/modlog.rs
@@ -113,6 +113,7 @@ async fn get_site_bans(
                         user: banned_user,
                         is_banned: view.mod_ban.banned,
                         reason: view.mod_ban.reason,
+                        expires: view.mod_ban.expires,
                     };
                     actions.push(action);
                 }
@@ -158,6 +159,7 @@ async fn get_community_bans(
                         community: Community::from(view.community),
                         is_banned: view.mod_ban_from_community.banned,
                         reason: view.mod_ban_from_community.reason,
+                        expires: view.mod_ban_from_community.expires,
                     };
                     actions.push(action);
                 }

--- a/crates/lemmy_client/src/person.rs
+++ b/crates/lemmy_client/src/person.rs
@@ -1,6 +1,7 @@
 use crate::endpoints::{ADMIN_PURGE_USER, USER, USER_BAN};
 use crate::model::Person;
 use crate::{Client, ClientError};
+use chrono::{DateTime, Utc};
 use lemmy_api_common::lemmy_db_schema::newtypes::PersonId;
 use lemmy_api_common::person::{BanPerson, GetPersonDetails, GetPersonDetailsResponse};
 use lemmy_api_common::site::PurgePerson;
@@ -52,17 +53,18 @@ pub async fn person_ban(
     client: &Client,
     person_id: i32,
     ban: bool,
-    purge: Option<bool>,
+    remove_content: Option<bool>,
     reason: Option<String>,
+    expires: Option<DateTime<Utc>>,
 ) -> Result<(), ClientError> {
     // Create request
     let path = USER_BAN;
     let params = BanPerson {
         person_id: PersonId(person_id),
         ban,
-        remove_data: purge,
+        remove_data: remove_content,
         reason,
-        ..Default::default()
+        expires: expires.map(|exp| exp.timestamp()),
     };
 
     // Perform request

--- a/crates/plugin_mod_log/src/lib.rs
+++ b/crates/plugin_mod_log/src/lib.rs
@@ -109,6 +109,7 @@ async fn federate_ban_action(
         moderator,
         user,
         is_banned,
+        expires,
         ..
     } = ban
     {
@@ -124,7 +125,9 @@ async fn federate_ban_action(
         if allowlist.contains(&moderator.instance) {
             // Perform ban locally
             let reason = format!("Federated ban from {}", moderator.instance);
-            if let Err(err) = person_ban(client, user.id, is_banned, None, Some(reason)).await {
+            if let Err(err) =
+                person_ban(client, user.id, is_banned, None, Some(reason), expires).await
+            {
                 println!("{}", err);
                 return;
             }

--- a/crates/plugin_private_message/src/commands.rs
+++ b/crates/plugin_private_message/src/commands.rs
@@ -3,9 +3,11 @@ use std::fmt::{Display, Formatter};
 const PREFIX: char = '!';
 const PURGE_USER: &str = "purge_user";
 const SITE_BAN: &str = "site_ban";
+const SITE_BAN_REMOVE: &str = "site_ban_remove";
 
 pub enum Commands {
     SiteBan(String, String),
+    SiteBanRemove(String, String),
     PurgeUser(String, String),
 }
 
@@ -26,6 +28,16 @@ impl Commands {
                 let reason = parts[2].to_string();
 
                 Some(Commands::PurgeUser(username, reason))
+            }
+            SITE_BAN_REMOVE => {
+                if parts.len() < 3 {
+                    return None;
+                }
+
+                let username = parts[1].to_string();
+                let reason = parts[2].to_string();
+
+                Some(Commands::SiteBanRemove(username, reason))
             }
             SITE_BAN => {
                 if parts.len() < 3 {
@@ -52,6 +64,15 @@ impl Display for Commands {
                      * user = {}\r\n\
                      * reason = `{}`",
                     PURGE_USER, username, reason
+                )
+            }
+            Commands::SiteBanRemove(username, reason) => {
+                write!(
+                    f,
+                    "* command = `{}`\r\n\
+                     * user = {}\r\n\
+                     * reason = `{}`",
+                    SITE_BAN_REMOVE, username, reason
                 )
             }
             Commands::SiteBan(username, reason) => {

--- a/docs/plugins/PrivateMessage.md
+++ b/docs/plugins/PrivateMessage.md
@@ -41,9 +41,16 @@ Performs a site ban against a specific user.
 Example:
 `!site_ban username reason`
 
+### site_ban_remove
+
+Performs a site ban against a specific user and removes their content.
+
+Example:
+`!site_ban_remove username reason`
+
 ### purge_user
 
-Purges a user's content.
+Purges a user's content. This does not currently federate!
 
 Example:
 `!purge_user username reason`


### PR DESCRIPTION
* Allows federating the ban expiration from allowed instances.
* Adds a command for ban+removing a user's content as purge does not currently federate.